### PR TITLE
Improve scoped taks with advanced yaml syntax

### DIFF
--- a/tasks/zsh-setup.yml
+++ b/tasks/zsh-setup.yml
@@ -1,35 +1,20 @@
 - name: Install ZSH
   apt: name=zsh
-  tags:
-    - install
-    - productivity
-    - dotfiles
-    - zsh
+  tags: &tags_for_zsh_tasks [ 'install', 'productivity', 'dotfiles', 'zsh' ]
+    
 - name: Change shell to zsh
   shell: chsh -s $(which zsh)
-  tags:
-    - install
-    - dotfiles
-    - productivity
-    - zsh
+  tags: *tags_for_zsh_tasks
 
 - name: Check that the somefile.conf exists
   stat:
     path: /home/theprimeagen/.oh-my-zsh
   register: oh_my_stats
-  tags:
-    - install
-    - productivity
-    - dotfiles
-    - zsh
+  tags: *tags_for_zsh_tasks
 
 - name: Oh-My-Zsh
   shell: curl -L https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh > ~/.oh-my-installer && chmod +x ~/.oh-my-installer && ~/.oh-my-installer
-  tags:
-    - install
-    - productivity
-    - dotfiles
-    - zsh
+  tags: *tags_for_zsh_tasks
   when: oh_my_stats.stat.exists == False
   become_user: theprimeagen
 
@@ -37,8 +22,4 @@
   ansible.builtin.git:
     repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
     dest: "~/.oh-my-zsh/plugins/zsh-autosuggestions"
-  tags:
-    - install
-    - productivity
-    - dotfiles
-    - zsh
+  tags: *tags_for_zsh_tasks


### PR DESCRIPTION
I notice that you're using the same tags for this "scoped" tasks. 
I propose you a refactor that make use of the [anchors and aliases](https://docs.ansible.com/ansible/latest/user_guide/playbooks_advanced_syntax.html#id2) of yaml language.
In this way you can define the variables just once and then just add one line for the other tasks.

![immagine](https://user-images.githubusercontent.com/22715417/147255217-7626598d-98d0-4b84-b1a4-121130710337.png)

If you prefer the alternative syntax for an array list you can also do that, no problem:
```yaml

- name: "Install ZSH"
  apt: name=zsh
  tags: &tags_for_zsh_tasks
    - install
    - productivity
    - dotfiles
    - zsh

...
```

There also another way (in case you need to override some tags for specific tasks), I found this works:

```yaml
- name: "Default variables for ZSH tasks" 
  shell: echo "Placeholder command, otherwise Ansible ask for an action"
  vars: &default_tags
    tags: [ 'install', 'zsh', 'dotfiles', 'zsh' ]

- name: "Install ZSH"
  apt: name=zsh
  <<: *default_tags

- name: Change shell to zsh
  shell: chsh -s $(which zsh)
  <<: *default_tags

...
```
unfortunately it seems a more verbose workaround.

I don't understand why yaml fragments **doesn't work** (I mean the extension fields) they are specific for this kind of needs:
```yaml

x-default-tags: &default_tags
  tags: ['your', 'tags' ]
  
- name: "Install ZSH"
  apt: name=zsh
  <<: *default_tags
  
```
Maybe this works only for docker-compose files ?    ¯\_(ツ)_/¯