### PR TITLE
added github.com to known hosts

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -32,3 +32,9 @@
     key: "{{ lookup('env', 'HOME') }}/.ssh/id_rsa.pub"
   with_fileglob:
   - "{{ lookup('env', 'HOME') }}/.ssh/*.pub"
+- name: Add github.com to known hosts
+  shell: ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+  tags:
+    - dotfiles
+    - install
+    - ssh


### PR DESCRIPTION
This pull request resolves a reproducibility problem coming up after trying to
follow Prime's actions in this official Frontend Masters Developer Productivity presentiation video:
https://youtu.be/qd3mfYS_Xow?t=247
when trying to run playbook with "-t dotfiles" in nvim-computer image, on step related to personal projects
we get "Host key verification failed" error when we first hit github.com over ssh (This is probably due execution sequence changes introduced to local.yml in commit 5b1d263).
This is resolved by adding github.com to known hosts in ssh.yml before trying to clone any repositories over ssh.
